### PR TITLE
add two ending possibilities

### DIFF
--- a/game/fight.rpy
+++ b/game/fight.rpy
@@ -6,6 +6,20 @@ label fight_the_investigators:
     $ pd.set_qualities_from_elimination()
     $ pd.calculate_mythos()
 
+    if pd.rocket_launcher:
+        menu:
+            "How will you attack the investigators?"
+
+            "Fire my rocket launcher at them!":
+                "You fire your rocket launcher at the investigators killing them all."
+                "That was easy."
+                $pd.investigators_remaining -= 4
+                jump scene_choosing
+
+
+            "Do something else":
+                "Let's keep the rocket launcher secret for now."
+
     menu:
         "How will you attack the investigators?"
 

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -79,12 +79,20 @@ label non_mythos_ending:
     "Tired, you start to drift off to slumber again. Perhaps for another thousand years."
     "However, just before you drift off to sleep, the investigators enter the room."
     "You feel powerless to stop them for the first time, but they simply take notice of you and move on."
-    "As you look down at your form, you realize the decisions you've made about yourself have transformed you into an ordinary [ps.animal]."
+    "As you look down at your form, you realize the decisions you've made about yourself have transformed you into an ordinary [pd.animal]."
     scene expression pd.animal
     $killed = 4-pd.investigators_remaining
+    if killed == 0:
+        return
     "However, all it not lost."
-    "You killed [killed] investigators and so have earned [killed] runes of the true name of the Great Old One."
     $runes = generate_runes(killed)
+    if killed == 1:
+        "You killed [killed] investigators and so have earned [killed] rune of the true name of the Great Old One."
+        "The Great Old One's name includes the rune: [runes]"
+    else:
+        "You killed [killed] investigators and so have earned [killed] runes of the true name of the Great Old One."
+        "The Great Old One's name includes the runes: [runes]"
+
 
     return
 

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -25,11 +25,11 @@ label start:
         $pd.set_quality("name", "Beast that Hath No Name")
         "Bold move! By not choosing a name, you resist being pinned down by knowledge."
         "But knowing that you defy naming is still knowledge about you."
-    elif pd.name_hash == '713a751b48086a13fe637a6056fc784b6467a960':
+    elif pd.name_hash == '161294bf3a4810d7b930c75d0013181e3467e365':
         $pd.rocket_launcher = True
         "[pd.get_quality('name')] is quite the fearsome name."
         "With a name like that you are probably equipped with a talking rocket launcher and ready to fight Fishsanto."
-    elif pd.name_hash == '4d890e8107fca409871daba22fa1cae97f618791':
+    elif pd.name_hash == '104c8e124a39017d6c2ed2894e66336fed149ead':
         $pd.the_hidden_name = True
         "[pd.get_quality('name')] is quite the fearsome name."
         "Truly it chills me to very core."
@@ -108,5 +108,11 @@ label win:
     return
 
 label mixed_ending:
-    "The investigators are dead or run off, but you are just a [pd.animal], so the world survives."
+    "As the last investigator dies at your hands, you feel tired."
+    "Your mythos power is gone."
+    "As you look at your form, you realize you are merely an ordinary [pd.animal], and no longer the eldritch monster you used to be."
+    "However, all it not lost."
+    "For killing all of the investigators you have earned 5 runes in the true name of the Great Old One."
+    $runes = generate_runes(5)
+    "The Great Old One's name includes the runes: [runes]"
     return

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -6,7 +6,7 @@
 # The game starts here.
 
 label start:
-    $ from utils import PlayerData, scene_chooser
+    $ from utils import PlayerData, scene_chooser, generate_runes
     $ pd = PlayerData()
     $ pd.reset_qualities()
 
@@ -25,6 +25,15 @@ label start:
         $pd.set_quality("name", "Beast that Hath No Name")
         "Bold move! By not choosing a name, you resist being pinned down by knowledge."
         "But knowing that you defy naming is still knowledge about you."
+    elif pd.name_hash == '713a751b48086a13fe637a6056fc784b6467a960':
+        $pd.rocket_launcher = True
+        "[pd.get_quality('name')] is quite the fearsome name."
+        "With a name like that you are probably equipped with a talking rocket launcher and ready to fight Fishsanto."
+    elif pd.name_hash == '4d890e8107fca409871daba22fa1cae97f618791':
+        $pd.the_hidden_name = True
+        "[pd.get_quality('name')] is quite the fearsome name."
+        "Truly it chills me to very core."
+        "You are surely an unknowable entity."
     else:
         "[pd.get_quality('name')] is quite the fearsome name."
         "But unfortunately being named defines something about you and harms your mythos power."
@@ -49,6 +58,7 @@ label scene_choosing:
     $ temp_cand = ", ".join(pd.candidate_names)
     "Remaining mythos power: [pd.mythos]"
     # "Remaining Candidates: [temp_cand]"
+    "Remaining investigators: [pd.investigators_remaining]"
 
     $ next_scene = scene_chooser(pd)
     jump expression next_scene
@@ -60,10 +70,22 @@ label scene_choosing:
 
 
 label non_mythos_ending:
-    "You are a [pd.animal]"
     if pd.animal == "horror":
         $ temp_path = ", ".join(pd.path)
-        "Your path was [temp_path]"
+        "Please take a screen shot of the next line and send it to the developer."
+        "The path that caused an error was: [temp_path]"
+        return
+    "As your mythos power leaves you from the choices you've made, you begin to feel weak."
+    "Tired, you start to drift off to slumber again. Perhaps for another thousand years."
+    "However, just before you drift off to sleep, the investigators enter the room."
+    "You feel powerless to stop them for the first time, but they simply take notice of you and move on."
+    "As you look down at your form, you realize the decisions you've made about yourself have transformed you into an ordinary [ps.animal]."
+    scene expression pd.animal
+    $killed = 4-pd.investigators_remaining
+    "However, all it not lost."
+    "You killed [killed] investigators and so have earned [killed] runes of the true name of the Great Old One."
+    $runes = generate_runes(killed)
+
     return
 
 label game_over:
@@ -73,7 +95,7 @@ label game_over:
     "Perhaps one day, your orbit will bring you close enough to Earth so you may have your revenge."
     return
 
-label winning:
+label win:
     "You destroy the Earth"
     return
 

--- a/game/selectors.rpy
+++ b/game/selectors.rpy
@@ -114,7 +114,7 @@ label claws_selector:
     menu:
         "This is the opportunity to pounce on one of them."
 
-        "They will never know what hit them. Attack now." if pd.get_quality("claws") is not False:
+        "Grab an investigator with your claws." if pd.get_quality("claws") is not False:
             if pd.get_revealed("claws"):
                 "You attempt to grab an investigator between your claws."
                 "The investigator is too quick and leaps out of the way, closing back in and holding your pincers together."

--- a/game/utils/__init__.py
+++ b/game/utils/__init__.py
@@ -1,2 +1,2 @@
 from .player_data import PlayerData, AnimalCandidate
-from .scene_chooser import scene_chooser
+from .scene_chooser import scene_chooser, generate_runes

--- a/game/utils/player_data.py
+++ b/game/utils/player_data.py
@@ -1,4 +1,5 @@
 from copy import copy
+from hashlib import sha1
 from dataclasses import dataclass
 
 
@@ -164,10 +165,17 @@ class PlayerData:
     candidate_names = []
     path = []
 
-    def set_quality(self, quality: str = None, val: bool = False) -> None:
+    rocket_launcher = False
+    the_hidden_name = False
+    name_hash = 0
+
+    def set_quality(self, quality: str = None, val: [bool,str] = False) -> None:
         if not quality:
             return
         self.qualities[quality] = val
+        if quality == "name":
+            val = "".join(sorted(val))
+            self.name_hash = sha1(val.encode('utf-8')).hexdigest()
 
     def set_revealed(self, quality: str = None, val: bool = False) -> None:
         if not quality:
@@ -202,9 +210,14 @@ class PlayerData:
         self.candidates = self.start_candidates[:]
         self.candidate_names = [item.get_quality('name') for item in self.candidates]
         self.path = []
+        self.rocket_launcher = False
+        self.the_hidden_name = False
+        self.name_hash = 0
 
     def calculate_mythos(self) -> None:
         self.mythos = len([q for q in self.qualities.values() if q is None])
+        if self.the_hidden_name:
+            self.mythos = 13
 
     def compare_to_candidates(self):
         for quality in self.qualities:

--- a/game/utils/player_data.py
+++ b/game/utils/player_data.py
@@ -174,7 +174,7 @@ class PlayerData:
             return
         self.qualities[quality] = val
         if quality == "name":
-            val = "".join(sorted(val))
+            val = "".join(list(set(sorted(val))))
             self.name_hash = sha1(val.encode('utf-8')).hexdigest()
 
     def set_revealed(self, quality: str = None, val: bool = False) -> None:

--- a/game/utils/scene_chooser.py
+++ b/game/utils/scene_chooser.py
@@ -1,4 +1,5 @@
-from random import choice
+from random import choice, randint
+import requests
 
 from .player_data import PlayerData
 
@@ -6,13 +7,30 @@ from .player_data import PlayerData
 def scene_chooser(pd: PlayerData) -> str:
     pd.set_qualities_from_elimination()
     pd.calculate_mythos()
+    if pd.the_hidden_name:
+        name = pd.get_quality("name")
+        investigators = pd.investigators_remaining
+        pd.reset_qualities()
+        pd.the_hidden_name = True
+        pd.set_quality("name", name)
+        pd.investigators_remaining = investigators
+
     if pd.investigators_remaining == pd.mythos == 0:
         return "mixed_ending"
     if pd.investigators_remaining == 0:
         return "win"
     if pd.mythos == 0:
         return "non_mythos_ending"
+
     remaining_unknowns = [q for q in pd.qualities if pd.qualities[q] is None]
     next_scene = choice(remaining_unknowns)
     pd.path.append(next_scene)
     return f"{next_scene}_selector"
+
+
+def generate_runes(n: int) -> str:
+    output = []
+    i = 0
+    while i < n:
+        output.append(chr(choice([67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109])))
+    return ",".join(output)

--- a/game/utils/scene_chooser.py
+++ b/game/utils/scene_chooser.py
@@ -33,4 +33,5 @@ def generate_runes(n: int) -> str:
     i = 0
     while i < n:
         output.append(chr(choice([67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109])))
+        i += 1
     return ",".join(output)


### PR DESCRIPTION
This adds the rocket launcher and true name features.

Each is governed by choosing a specific name during name selection. Arguably finding the true name feature is the legitimate way to beat the game and the rocket launcher ending is just an easter egg. The required names are hashed instead of being stored in code as plaintext. I view reversing the hash or otherwise using the code to engineer the true name as a valid method of beating the game.